### PR TITLE
feat: don't re-evaluate flags when user changes ip address

### DIFF
--- a/internal/service/model.go
+++ b/internal/service/model.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/uw-labs/flaggio/internal/flaggio"
 	"github.com/victorkt/clientip"
 	"github.com/vmihailenco/msgpack/v4"
+
+	"github.com/uw-labs/flaggio/internal/flaggio"
 )
 
 // EvaluationRequest is the evaluation request object
@@ -34,6 +35,10 @@ func (er EvaluationRequest) IsDebug() bool {
 	return er.Debug != nil && *er.Debug
 }
 
+var hashContextBlacklist = map[string]struct{}{
+	"$ip": {},
+}
+
 // Hash returns a hash string representation of EvaluationRequest
 // This function will return the same hash regardless of the order
 // the user context comes in.
@@ -41,6 +46,9 @@ func (er EvaluationRequest) Hash() (string, error) {
 	// sort user context keys
 	var contextKeys []string
 	for key := range er.UserContext {
+		if _, blacklisted := hashContextBlacklist[key]; blacklisted {
+			continue
+		}
 		contextKeys = append(contextKeys, key)
 	}
 	sort.Strings(contextKeys)

--- a/internal/service/model_test.go
+++ b/internal/service/model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/flaggio"
 	"github.com/uw-labs/flaggio/internal/service"
 )
@@ -33,6 +34,21 @@ func TestEvaluationRequest_Hash(t *testing.T) {
 			req: service.EvaluationRequest{
 				UserID: "123",
 				UserContext: flaggio.UserContext{
+					"cde": "456",
+					"abc": 123,
+					"ghi": nil,
+					"efg": true,
+				},
+				Debug: nil,
+			},
+			expectedHash: "78c77cefc3d6a062e7c29140c4aef97be2d8e0c4",
+		},
+		{
+			name: "ignores blacklisted context attributes",
+			req: service.EvaluationRequest{
+				UserID: "123",
+				UserContext: flaggio.UserContext{
+					"$ip": "127.0.0.1",
 					"cde": "456",
 					"abc": 123,
 					"ghi": nil,


### PR DESCRIPTION
BREAKING CHANGE

This makes it so flaggio doesn't re-evaluate flags when the user changes their ip address