### PR TITLE
feat(breaking): ignore non-string user values

### DIFF
--- a/cmd/flaggio/infra.go
+++ b/cmd/flaggio/infra.go
@@ -15,11 +15,12 @@ import (
 
 func newHTTPServer(ctx context.Context, addr string, handler http.Handler, logger *logrus.Entry, wg *sync.WaitGroup) *http.Server {
 	srv := &http.Server{
-		Addr:         addr,
-		Handler:      handler,
-		WriteTimeout: 10 * time.Second,
-		ReadTimeout:  10 * time.Second,
-		IdleTimeout:  15 * time.Second,
+		Addr:              addr,
+		Handler:           handler,
+		WriteTimeout:      10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       15 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	wg.Add(1)

--- a/internal/operator/contains.go
+++ b/internal/operator/contains.go
@@ -9,11 +9,7 @@ import (
 // any of the configured values on the flag.
 func Contains(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := contains(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if contains(v, usrValue) {
 			return true, nil
 		}
 	}
@@ -24,29 +20,25 @@ func Contains(usrValue interface{}, validValues []interface{}) (bool, error) {
 // any of the configured values on the flag.
 func DoesntContain(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := contains(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if contains(v, usrValue) {
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func contains(cnstrnValue, userValue interface{}) (bool, error) {
+func contains(cnstrnValue, userValue interface{}) bool {
 	str, err := toString(userValue)
 	if err != nil {
-		return false, err
+		return false
 	}
 	switch v := cnstrnValue.(type) {
 	case string:
-		return strings.Contains(str, v), nil
+		return strings.Contains(str, v)
 	case []byte:
-		return strings.Contains(str, string(v)), nil
+		return strings.Contains(str, string(v))
 	default:
-		return false, nil
+		return false
 	}
 }
 

--- a/internal/operator/contains_test.go
+++ b/internal/operator/contains_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/operator"
 )
 
@@ -39,10 +40,17 @@ func TestContains(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: false,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: false,
 		},
 	}
@@ -90,10 +98,17 @@ func TestDoesntContain(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: true,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: true,
 		},
 	}

--- a/internal/operator/endswith.go
+++ b/internal/operator/endswith.go
@@ -8,11 +8,7 @@ import (
 // any of the configured values on the flag.
 func EndsWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := endsWith(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if endsWith(v, usrValue) {
 			return true, nil
 		}
 	}
@@ -23,28 +19,24 @@ func EndsWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 // any of the configured values on the flag.
 func DoesntEndWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := endsWith(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if endsWith(v, usrValue) {
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func endsWith(cnstrnValue, userValue interface{}) (bool, error) {
+func endsWith(cnstrnValue, userValue interface{}) bool {
 	str, err := toString(userValue)
 	if err != nil {
-		return false, err
+		return false
 	}
 	switch v := cnstrnValue.(type) {
 	case string:
-		return strings.HasSuffix(str, v), nil
+		return strings.HasSuffix(str, v)
 	case []byte:
-		return strings.HasSuffix(str, string(v)), nil
+		return strings.HasSuffix(str, string(v))
 	default:
-		return false, nil
+		return false
 	}
 }

--- a/internal/operator/endswith_test.go
+++ b/internal/operator/endswith_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/operator"
 )
 
@@ -39,10 +40,17 @@ func TestEndsWith(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: false,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: false,
 		},
 	}
@@ -90,10 +98,17 @@ func TestDoesntEndWith(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: true,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: true,
 		},
 	}

--- a/internal/operator/innetwork.go
+++ b/internal/operator/innetwork.go
@@ -22,7 +22,7 @@ func InNetwork(usrValue interface{}, validValues []interface{}) (bool, error) {
 func inNetwork(cnstrnValue, userValue interface{}) (bool, error) {
 	u, err := toString(userValue)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	v, ok := cnstrnValue.(string)
 	if !ok {

--- a/internal/operator/innetwork_test.go
+++ b/internal/operator/innetwork_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/operator"
 )
 
@@ -46,10 +47,17 @@ func TestInNetwork(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"$ip": "abcdef"},
 			property:       "$ip",
 			values:         []interface{}{struct{}{}},
+			expectedResult: false,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"$ip": nil},
+			property:       "$ip",
+			values:         []interface{}{"2001:0db9:0:0:0:0:0:0/32"},
 			expectedResult: false,
 		},
 	}

--- a/internal/operator/oneof.go
+++ b/internal/operator/oneof.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 )
@@ -61,7 +62,7 @@ func equals(cnstrnValue, userValue interface{}) (bool, error) {
 		if !ok {
 			return false, nil
 		}
-		return string(v) == string(uv), nil
+		return bytes.Equal(v, uv), nil
 	default:
 		return false, nil
 	}

--- a/internal/operator/regex.go
+++ b/internal/operator/regex.go
@@ -37,7 +37,7 @@ func DoesntMatchRegex(usrValue interface{}, validValues []interface{}) (bool, er
 func matches(cnstrnValue, userValue interface{}) (bool, error) {
 	str, err := toString(userValue)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	switch v := cnstrnValue.(type) {
 	case string:

--- a/internal/operator/regex_test.go
+++ b/internal/operator/regex_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/operator"
 )
 
@@ -38,10 +39,17 @@ func TestMatchesRegex(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: false,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: false,
 		},
 	}
@@ -87,10 +95,17 @@ func TestDoesntMatchRegex(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: true,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: true,
 		},
 	}

--- a/internal/operator/startswith.go
+++ b/internal/operator/startswith.go
@@ -8,11 +8,7 @@ import (
 // any of the configured values on the flag.
 func StartsWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := startsWith(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if startsWith(v, usrValue) {
 			return true, nil
 		}
 	}
@@ -23,28 +19,24 @@ func StartsWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 // any of the configured values on the flag.
 func DoesntStartWith(usrValue interface{}, validValues []interface{}) (bool, error) {
 	for _, v := range validValues {
-		ok, err := startsWith(v, usrValue)
-		if err != nil {
-			return false, err
-		}
-		if ok {
+		if startsWith(v, usrValue) {
 			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func startsWith(cnstrnValue, userValue interface{}) (bool, error) {
+func startsWith(cnstrnValue, userValue interface{}) bool {
 	str, err := toString(userValue)
 	if err != nil {
-		return false, err
+		return false
 	}
 	switch v := cnstrnValue.(type) {
 	case string:
-		return strings.HasPrefix(str, v), nil
+		return strings.HasPrefix(str, v)
 	case []byte:
-		return strings.HasPrefix(str, string(v)), nil
+		return strings.HasPrefix(str, string(v))
 	default:
-		return false, nil
+		return false
 	}
 }

--- a/internal/operator/startswith_test.go
+++ b/internal/operator/startswith_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uw-labs/flaggio/internal/operator"
 )
 
@@ -38,10 +39,17 @@ func TestStartsWith(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: false,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: false,
 		},
 	}
@@ -87,10 +95,17 @@ func TestDoesntStartWith(t *testing.T) {
 		},
 		// ========================================================================
 		{
-			name:           "unknown type",
+			name:           "unknown config type",
 			usrContext:     map[string]interface{}{"prop": "abcdef"},
 			property:       "prop",
 			values:         []interface{}{struct{}{}},
+			expectedResult: true,
+		},
+		{
+			name:           "non-string user type",
+			usrContext:     map[string]interface{}{"prop": nil},
+			property:       "prop",
+			values:         []interface{}{"cde"},
 			expectedResult: true,
 		},
 	}


### PR DESCRIPTION
There is no value in returning an error for these operators when the user provides a non-string value (or even don't provide the expected value). For this reason, the api will assume the values don't match.